### PR TITLE
Process files only once

### DIFF
--- a/handbrake/src/convert.sh
+++ b/handbrake/src/convert.sh
@@ -14,12 +14,19 @@ PRESET=Ipad
 SRC=/nobody/.config/ghb/Watch-Folder
 DEST=/Output
 HANDBRAKE_CLI=HandBrakeCLI
+FILE_LIST=/nobody/.config/ghb/processed_files.dat
 
 
 
 IFS=$(echo -en "\n\b")
 for FILE in `ls $SRC`
 do
+        # Hash the file details for some privacy. Also hash the inode number, since sometimes people will want to
+        # re-encode the same file by placing it back in the dir.
+        file_hash=$(stat -c '%i %s %n' "$FILE" | md5sum | awk '{print $1}')
+
+        if grep -q "$file_hash" "$FILE_LIST"; then continue; fi
+
         filename=$(basename $FILE)
         extension=${filename##*.}
         filename=${filename%.*}
@@ -28,4 +35,8 @@ do
 
 chown nobody:users $DEST/$filename.$DEST_EXT
 
+        # Should we only remember the hash for the file if handbrake succeeded? If we do that, we'll keep trying to
+        # convert the same file over and over. This way is simpler. If they want to re-encode, rename the file, or move
+        # it out and back into the watch folder.
+        echo $file_hash >> $FILE_LIST
 done

--- a/handbrake/src/convert.sh
+++ b/handbrake/src/convert.sh
@@ -23,7 +23,7 @@ for FILE in `ls $SRC`
 do
         # Hash the file details for some privacy. Also hash the inode number, since sometimes people will want to
         # re-encode the same file by placing it back in the dir.
-        file_hash=$(stat -c '%i %s %n' "$FILE" | md5sum | awk '{print $1}')
+        file_hash=$(stat -c '%i %s %n' "$SRC/$FILE" | md5sum | awk '{print $1}')
 
         if grep -q "$file_hash" "$FILE_LIST"; then continue; fi
 


### PR DESCRIPTION
Adds a state file in the config dir to record which files have already been processed.

That way if files are already in the watch folder, then a new file is added, we don't re-process the previously existing
files. (Deleting all our work from before by overwriting the files in the output dir!)

I hash the inode+size+filename and store that, for a little privacy.