### PR TITLE
Improved Watch Dir Monitoring and README

### DIFF
--- a/handbrake/Dockerfile
+++ b/handbrake/Dockerfile
@@ -50,3 +50,5 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 (( find /usr/share/doc -empty|xargs rmdir || true ))
 
 VOLUME ["/Watch", "/Output", "/nobody/.config/ghb"]
+
+EXPOSE 3389

--- a/handbrake/Dockerfile
+++ b/handbrake/Dockerfile
@@ -49,6 +49,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 (( find /usr/share/doc -depth -type f ! -name copyright|xargs rm || true )) && \
 (( find /usr/share/doc -empty|xargs rmdir || true ))
 
-VOLUME ["/Watch", "/Output", "/nobody/.config/ghb"]
+VOLUME ["/Movies", "/Watch", "/Output", "/nobody/.config/ghb"]
 
 EXPOSE 3389

--- a/handbrake/Dockerfile
+++ b/handbrake/Dockerfile
@@ -12,7 +12,7 @@ ADD src/ /
 # startup file. Use coppit's monitoring script from the inotify-command container. Revision-lock to a specific version
 # to avoid any surprises.
 RUN wget -O /runas.sh \
-  'https://raw.githubusercontent.com/coppit/docker-inotify-command/d0b25a4ed40582f5e2d21282c32c58164495c07b/runas.sh' && \
+  'https://raw.githubusercontent.com/coppit/docker-inotify-command/1401a636bbc9369141d0d32ac7b80c2bf7fcdbcb/runas.sh' && \
 chmod +x /runas.sh && \
 wget -O /monitor.py \
   'https://raw.githubusercontent.com/coppit/docker-inotify-command/1401a636bbc9369141d0d32ac7b80c2bf7fcdbcb/monitor.py' && \

--- a/handbrake/Dockerfile
+++ b/handbrake/Dockerfile
@@ -9,8 +9,16 @@ CMD ["/sbin/my_init"]
 # Add local files
 ADD src/ /
 
-# startup file
-RUN mkdir /etc/service/inotify && \
+# startup file. Use coppit's monitoring script from the inotify-command container. Revision-lock to a specific version
+# to avoid any surprises.
+RUN wget -O /runas.sh \
+  'https://raw.githubusercontent.com/coppit/docker-inotify-command/d0b25a4ed40582f5e2d21282c32c58164495c07b/runas.sh' && \
+chmod +x /runas.sh && \
+wget -O /monitor.py \
+  'https://raw.githubusercontent.com/coppit/docker-inotify-command/1401a636bbc9369141d0d32ac7b80c2bf7fcdbcb/monitor.py' && \
+sed -i 's/^RUNAS.*/RUNAS = "\/runas.sh"/' /monitor.py && \
+chmod +x /monitor.py && \
+mkdir /etc/service/inotify && \
 mv /inotify.sh /etc/service/inotify/run && \
 chmod +x /etc/service/inotify/run && \
 mv /copy-script.sh /etc/my_init.d/copy-script.sh && \
@@ -28,7 +36,10 @@ apt-get install -qy \
 handbrake-gtk \
 handbrake-cli \
 gnome-themes-standard \ 
-inotify-tools && \
+python3-setuptools && \
+
+# install watchdog module for Python3
+easy_install3 watchdog && \
 
 # clean up
 apt-get clean && \
@@ -37,3 +48,5 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
 /usr/share/lintian /usr/share/linda /var/cache/man && \
 (( find /usr/share/doc -depth -type f ! -name copyright|xargs rm || true )) && \
 (( find /usr/share/doc -empty|xargs rmdir || true ))
+
+VOLUME ["/Watch", "/Output", "/nobody/.config/ghb"]

--- a/handbrake/README.md
+++ b/handbrake/README.md
@@ -1,0 +1,44 @@
+HandBrake
+=========
+
+This is a Docker container for running [HandBrake](https://handbrake.fr/), video encoder. Both interactive and noninteractive versions are included.
+
+Usage
+-----
+
+To use this container for a user interface to HandBrake:
+
+`docker run --name=HandBrakeUI -e WIDTH=1280 -e HEIGHT=720 -p 3389:3389 -p 8080:8080 -v /path/to/movies/dir:/Movies:rw -v /path/to/config:/nobody/.config/ghb:rw sparklyballs/handbrake`
+
+In this mode, the /Movies path in the container is shared with the host, so put movies that you want to convert there, along with the converted movies.
+
+There are two ways to use the interactive user interface. One is to connect to the UI in your web browser with the URL http://host:8080/#/client/c/HandBrake. The second is to connect with a remote desktop client using port 3389. There are RDP clients for multiple platforms:
+
+* Microsoft Remote Desktop for Windows (built into the OS)
+* [Microsoft Remote Desktop for OS X](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417?mt=12)
+* [rdesktop for Linux](http://www.rdesktop.org/)
+
+Of course, if you change the host ports, then when you connect you'll have to specify the server as `<host ip>:<host port>`. Feel free to drop the 3389 mapping if you don't plan to use RDP, or the 8080 mapping if you don't plan to use the web browser.  
+
+If you want to run the container without a UI:
+
+`docker run --name=HandBrakeCLI -v /path/to/watch/dir:/Watch:r -v /path/to/output/dir:/Output:rw -v /path/to/config:/nobody/.config/ghb:rw sparklyballs/handbrake`
+
+In this mode, drop the files into /path/to/watch/dir, and they will be encoded into /path/to/output/dir.
+
+You can also combine all of the flags into one big command, to support both the UI as well as the automated conversion.
+
+Configuration
+-------------
+
+After your container is launched the first time, a folder called "Convert-Script" will be created in your config directory. Edit that file to change the settings used for the automatic conversion. Set `DEST_EXT` to the extension (and therefor file format) of the output file. Set `PRESET` to the name of a HandBrake preset. For a complete list of presets, visit [this page](https://handbrake.fr/docs/en/latest/technical/official-presets.html).
+
+You can also configure the monitoring behavior by setting certain Docker container values when running the container (-e flag):
+
+`SETTLE_DURATION`: Default 10. Wait for this amount of seconds for the watch directory to stop getting changes. This prevents HandBrake from running on a partially written file, for instance.
+
+`MAX_WAIT_TIME`: Default 5:00. If the watch directory doesn't settle for `SETTLE_DURATION` within this time, run HandBrake anyway. This is to avoid waiting forever if there is a constant stream of changes to the directory. Note that this will cause HandBrake to operate on incomplete files!
+
+`MIN_PERIOD`: Default 0. Wait at least this amount of time before running HandBrake again. This can be used to force a delay before HandBrake runs again, even if there are more detected changes. The default value of 0 allows back-to-back execution.
+
+For all of the above settings, the time can be in the format HH:MM:SS, MM:SS, or SS.

--- a/handbrake/src/HandBrake.conf
+++ b/handbrake/src/HandBrake.conf
@@ -1,0 +1,28 @@
+# The folder to monitor for changes
+WATCH_DIR=/Watch
+
+# If we don't see any events for $SETTLE_DURATION time, assume that it's safe to run HandBrake. Format is HH:MM:SS,
+# with HH and MM optional.
+SETTLE_DURATION=10
+
+# However, if we see a stream of changes for longer than $MAX_WAIT_TIME with no break of $SETTLE_DURATION or more, then
+# go ahead and run HandBrake. Otherwise we might be waiting forever for the directory to stop changing. Format is
+# HH:MM:SS, with HH and MM optional.
+MAX_WAIT_TIME=01:00
+
+# After processing all the files in the watch dir, wait at least this long before doing it again, even if
+# $SETTLE_DURATION time has passed after change. This controls the maximum frequency of the scans and conversions.
+MIN_PERIOD=0
+
+# Set this to 1 to log all events, for debugging purposes. WARNING! This creates copious amounts of confusing logging!
+DEBUG=0
+
+# Run the program as this user and group ID, which should match up with the host.
+USER_ID=$(id -u nobody)
+GROUP_ID=$(id -g nobody)
+UMASK=0000
+
+# HandBrake doesn't write to the watch dir, so it's safe to keep watching for events.
+IGNORE_EVENTS_WHILE_COMMAND_IS_RUNNING=0
+
+COMMAND='/bin/bash /nobody/.config/ghb/Convert-Script/convert.sh'

--- a/handbrake/src/HandBrake.conf
+++ b/handbrake/src/HandBrake.conf
@@ -8,7 +8,7 @@ SETTLE_DURATION=10
 # However, if we see a stream of changes for longer than $MAX_WAIT_TIME with no break of $SETTLE_DURATION or more, then
 # go ahead and run HandBrake. Otherwise we might be waiting forever for the directory to stop changing. Format is
 # HH:MM:SS, with HH and MM optional.
-MAX_WAIT_TIME=01:00
+MAX_WAIT_TIME=10:00
 
 # After processing all the files in the watch dir, wait at least this long before doing it again, even if
 # $SETTLE_DURATION time has passed after change. This controls the maximum frequency of the scans and conversions.

--- a/handbrake/src/convert.sh
+++ b/handbrake/src/convert.sh
@@ -11,7 +11,7 @@ PRESET=Ipad
 
 ##### DO NOT CHANGE ANYTHING BELOW HERE ###############
 
-SRC=/nobody/.config/ghb/Watch-Folder
+SRC=/Watch
 DEST=/Output
 HANDBRAKE_CLI=HandBrakeCLI
 

--- a/handbrake/src/copy-script.sh
+++ b/handbrake/src/copy-script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-mkdir -p /nobody/.config/ghb/Convert-Script /nobody/.config/ghb/Watch-Folder
+mkdir -p /nobody/.config/ghb/Convert-Script
 chown -R nobody:users /nobody/.config/ghb
 if [ -f "/nobody/.config/ghb/Convert-Script/convert.sh" ]; then
 echo "using existing script, may require editing"

--- a/handbrake/src/copy-script.sh
+++ b/handbrake/src/copy-script.sh
@@ -2,11 +2,14 @@
 mkdir -p /nobody/.config/ghb/Convert-Script
 chown -R nobody:users /nobody/.config/ghb
 if [ -f "/nobody/.config/ghb/Convert-Script/convert.sh" ]; then
-echo "using existing script, may require editing"
-chown -R nobody:users /nobody/.config/ghb
-chmod +x /nobody/.config/ghb/Convert-Script/convert.sh
+    echo "using existing script, may require editing"
+    chown -R nobody:users /nobody/.config/ghb
+    chmod +x /nobody/.config/ghb/Convert-Script/convert.sh
+
+    # Auto-convert older scripts to use the new /Watch directory
+    sed -i 's#SRC=/nobody/.config/ghb/Watch-Folder#SRC=/Watch#' /nobody/.config/ghb/Convert-Script/convert.sh
 else
-cp /convert.sh /nobody/.config/ghb/Convert-Script/convert.sh
-chmod +x /nobody/.config/ghb/Convert-Script/convert.sh
-chown -R nobody:users /nobody/.config/ghb
+    cp /convert.sh /nobody/.config/ghb/Convert-Script/convert.sh
+    chmod +x /nobody/.config/ghb/Convert-Script/convert.sh
+    chown -R nobody:users /nobody/.config/ghb
 fi

--- a/handbrake/src/inotify.sh
+++ b/handbrake/src/inotify.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
-while inotifywait -r -e create,moved_to /nobody/.config/ghb/Watch-Folder; do
-/bin/bash /nobody/.config/ghb/Convert-Script/convert.sh
-echo "Converting file(s)"
-done
+
+exec /monitor.py /HandBrake.conf


### PR DESCRIPTION
One thing I noticed about the current inotify monitoring is that if I copied a big file from my array into the cache drive watch folder, HandBrake would start working on it before the file was done copying. This pull request uses a monitor.py script that I wrote, which waits for a "stabilization period" before running the command. BTW, the "watchdog" Python module uses inotify underneath.

The monitor.py script also uses a "runas.sh" script, which creates user and group IDs in the container to match the desired host UID/GID. I see that you already set up a "nobody" user in the container to match unraid, but of course that makes this container unraid-specific.

Additional changes: I exposed port 3389 for RDP access, and added a README. I also moved the Watch folder to /Watch, which made more sense to me than making it a subfolder of the config folder.