### PR TITLE
Add support for running "nice" on HandBrake

### DIFF
--- a/handbrake/src/convert.sh
+++ b/handbrake/src/convert.sh
@@ -24,7 +24,7 @@ do
         extension=${filename##*.}
         filename=${filename%.*}
 
-        $HANDBRAKE_CLI -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset $PRESET
+        $HANDBRAKE_CLI -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset $PRESET &
 
         PID=$!
         # This might fail if the user has not provided --cap-add=CAP_SYS_NICE to the container. So ignore failures here.

--- a/handbrake/src/convert.sh
+++ b/handbrake/src/convert.sh
@@ -26,6 +26,11 @@ do
 
         $HANDBRAKE_CLI -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset $PRESET
 
+        PID=$!
+        # This might fail if the user has not provided --cap-add=CAP_SYS_NICE to the container. So ignore failures here.
+        renice 19 $PID
+        wait $PID
+
 chown nobody:users $DEST/$filename.$DEST_EXT
 
 done


### PR DESCRIPTION
This allows me to give 8 CPUs to the container, but still browse the web in my VM. Not quite good enough to play a game though.

The user can control this with the --cap-add SYS_NICE container option.

If this pull request and my other one with the README.md gets accepted, I'll also add documentation about this capability to the README.md